### PR TITLE
Installation scripts for CUDA, NCCL and CUDNN on multiple servers

### DIFF
--- a/opensetAlgos/EVM.py
+++ b/opensetAlgos/EVM.py
@@ -93,7 +93,8 @@ def EVM_Training(pos_classes_to_process, features_all_classes, args, gpu, models
         positive_cls_feature = features_all_classes[pos_cls_name].to(f"cuda:{gpu}")
         tailsize = max(args.tailsize)
         if tailsize<=1:
-            tailsize = int(tailsize*positive_cls_feature.shape[0])
+            tailsize = tailsize*positive_cls_feature.shape[0]
+        tailsize=int(tailsize)
 
         negative_classes_for_current_class=[]
         temp = []
@@ -142,7 +143,7 @@ def EVM_Training(pos_classes_to_process, features_all_classes, args, gpu, models
             if org_tailsize <= 1:
                 tailsize = int(org_tailsize * positive_cls_feature.shape[0])
             else:
-                tailsize = org_tailsize
+                tailsize = int(org_tailsize)
             # Perform actual EVM training
             weibull_model = fit_low(bottom_k_distances, distance_multiplier, tailsize, gpu)
             extreme_vectors_models, extreme_vectors_indexes, covered_vectors = set_cover(weibull_model,

--- a/standAloneTools/cuda_nccl_cudnn_setup.bash
+++ b/standAloneTools/cuda_nccl_cudnn_setup.bash
@@ -1,0 +1,45 @@
+touninstall=(
+    "*cublas*"
+    "cuda*"
+    "nsight*"
+    "nvidia*"
+    "*nvidia*"
+    "nccl*"
+    "cudnn*"
+)
+
+cuda_install_file="cuda_11.1.1_455.32.00_linux.run"
+toinstall=(
+    "libcudnn8_8.1.1.33-1+cuda11.2_amd64.deb"
+    "nccl-local-repo-ubuntu1804-2.8.4-cuda11.1_1.0-1_amd64.deb"
+)
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+packages_path="/scratch/adhamija/cuda_packages/"
+mkdir -p $packages_path
+rsync -zarvh adhamija@quicksilver.vast.uccs.edu:$packages_path $packages_path
+cd $packages_path
+
+CUDA_UNINSTALLER=/usr/local/cuda/bin/cuda-uninstaller
+if test -f "$CUDA_UNINSTALLER"; then
+    echo -e "${RED}Uninstalling CUDA using $CUDA_UNINSTALLER${NC}"
+    sh $CUDA_UNINSTALLER
+else
+    echo -e "${RED}Could not find uninstall script at $CUDA_UNINSTALLER${NC} press enter to continue"
+    read varname
+fi
+
+echo -e "${RED}Uninstalling package ${touninstall[@]}${NC}"
+apt-get -qq --yes --purge remove "${touninstall[@]}"
+apt-get -qq --yes autoremove
+apt-get -qq --yes autoclean
+rm -rf /usr/local/cuda*
+
+echo -e "${RED}Installing cuda using $cuda_install_file${NC}"
+sh $cuda_install_file
+
+echo -e "${RED}Installing packages ${toinstall[@]}${NC}"
+dpkg -i "${toinstall[@]}"
+
+

--- a/standAloneTools/cuda_nccl_cudnn_setup.bash
+++ b/standAloneTools/cuda_nccl_cudnn_setup.bash
@@ -1,3 +1,8 @@
+#!/bin/bash
+
+RSYNCALIAS=$1
+ALTCP=${2:-adhamija}
+
 touninstall=(
     "*cublas*"
     "cuda*"
@@ -16,9 +21,9 @@ toinstall=(
 
 RED='\033[0;31m'
 NC='\033[0m' # No Color
-packages_path="/scratch/adhamija/cuda_packages/"
+packages_path="/scratch/"$ALTCP"/cuda_packages/"
 mkdir -p $packages_path
-rsync -zarvh adhamija@quicksilver.vast.uccs.edu:$packages_path $packages_path
+rsync -zarvh $RSYNCALIAS@quicksilver.vast.uccs.edu:$packages_path $packages_path
 cd $packages_path
 
 CUDA_UNINSTALLER=/usr/local/cuda/bin/cuda-uninstaller

--- a/standAloneTools/run_on_all_servers.bash
+++ b/standAloneTools/run_on_all_servers.bash
@@ -1,0 +1,10 @@
+servers=(
+    "patriot"
+    "pepper"
+)
+for i in "${servers[@]}"; do
+    echo "Running on $i"
+    scp cuda_nccl_cudnn_setup.bash adhamija@$i.vast.uccs.edu:/tmp/
+    ssh -t adhamija@$i.vast.uccs.edu "sudo bash /tmp/cuda_nccl_cudnn_setup.bash"
+done
+

--- a/standAloneTools/run_on_all_servers.bash
+++ b/standAloneTools/run_on_all_servers.bash
@@ -1,10 +1,13 @@
+#!/bin/bash
+
+SSHNAME=$1
+
 servers=(
     "patriot"
     "pepper"
 )
 for i in "${servers[@]}"; do
     echo "Running on $i"
-    scp cuda_nccl_cudnn_setup.bash adhamija@$i.vast.uccs.edu:/tmp/
-    ssh -t adhamija@$i.vast.uccs.edu "sudo bash /tmp/cuda_nccl_cudnn_setup.bash"
+    scp cuda_nccl_cudnn_setup.bash $SSHNAME@$i.vast.uccs.edu:/tmp/
+    ssh -t $SSHNAME@$i.vast.uccs.edu "sudo bash /tmp/cuda_nccl_cudnn_setup.bash"
 done
-


### PR DESCRIPTION
This pull request has two major scripts 
1) `standAloneTools/cuda_nccl_cudnn_setup.bash` which uninstalls all existing cuda and nvidia drivers, copies installation scripts from a remote location and makes a fresh install
2) `standAloneTools/run_on_all_servers.bash` that runs the above script on a list of servers.
Both the scripts can be independently run but have to be run as `sudo bash <script_name>`.

The pull request also has a minor bug fix for the evm code.