### PR TITLE
Reading HDF5 feature files with classes containing only single features

### DIFF
--- a/vast/data_prep/readHDF5.py
+++ b/vast/data_prep/readHDF5.py
@@ -57,7 +57,9 @@ def read_features(args, feature_file_names=None, cls_to_process=None):
                 image_names = hf[cls]["image_names"][()].tolist()
             else:
                 image_names = None
-            features = torch.cat(temp, dim=1)
+            if len(temp[0].shape) == 1:
+                temp[0] = temp[0][None,:]
+            features = torch.cat(temp,dim=0)
             yield cls, features, image_names
     finally:
         for h in h5_objs:


### PR DESCRIPTION
This pull request adds support to readHDF5.py - read_features() method, enabling the parsing of HDF5 feature files when some classes have only one sample. In the current state of vast, this use case causes a crash.