### PR TITLE
Allowing to select GPU

### DIFF
--- a/vast/__init__.py
+++ b/vast/__init__.py
@@ -1,0 +1,5 @@
+from . import tools
+from . import losses
+from . import architectures
+from . import activations
+from . import eval

--- a/vast/eval/__init__.py
+++ b/vast/eval/__init__.py
@@ -1,0 +1,1 @@
+from .eval import *

--- a/vast/eval/eval.py
+++ b/vast/eval/eval.py
@@ -1,5 +1,5 @@
 import torch
-from vast.tools import device, set_device_cpu
+from ..tools import device, set_device_cpu
 
 set_device_cpu()
 

--- a/vast/tools/__init__.py
+++ b/vast/tools/__init__.py
@@ -20,4 +20,11 @@ def device(x):
 
 def set_device_cpu():
     global _device
-    _device = "cpu"
+    import torch
+    _device = torch.device("cpu")
+
+
+def set_device_gpu(index=0):
+    global _device
+    import torch
+    _device = torch.device(f"cuda:{index}"}


### PR DESCRIPTION
Currently, only the GPU with logical index 0 can be used and will automatically be selected when available. This PR provides the possibility to select a different GPU in a multi-GPU machine.