### PR TITLE
Added possibility to select GPU device on multi-gpu system

### DIFF
--- a/vast/tools/__init__.py
+++ b/vast/tools/__init__.py
@@ -27,4 +27,4 @@ def set_device_cpu():
 def set_device_gpu(index=0):
     global _device
     import torch
-    _device = torch.device(f"cuda:{index}"}
+    _device = torch.device(f"cuda:{index}")

--- a/vast/tools/__init__.py
+++ b/vast/tools/__init__.py
@@ -20,4 +20,11 @@ def device(x):
 
 def set_device_cpu():
     global _device
-    _device = "cpu"
+    import torch
+    _device = torch.device("cpu")
+
+
+def set_device_gpu(index=0):
+    global _device
+    import torch
+    _device = torch.device(f"cuda:{index}"}


### PR DESCRIPTION
By default, only the GPU with logical ID 0 was able to be selected. Now, I added the possibility to add a different GPU on a multi-GPU system.